### PR TITLE
Migrated to cassandra driver 3.1.1 and new pooling options

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,10 +50,15 @@ The main configuration is via the normal config.json file for a Vert.x module.
         "pooling": {
             "core_connections_per_host_local": <int>,
             "core_connections_per_host_remote": <int>,
+            "heartbeat_interval_seconds": <int>,
+            "idle_timeout_seconds": <int>,
+            "max_queue_size": <int>,
+            "max_requests_per_connection_local": <int>,
+            "max_requests_per_connection_remote": <int>,
             "max_connections_per_host_local": <int>,
             "max_connections_per_host_remote": <int>,
-            "max_simultaneous_requests_local": <int>,
-            "max_simultaneous_requests_remote": <int>
+            "new_connection_threshold_local": <int>,
+            "new_connection_threshold_remote": <int>
         },
         
         "socket": {

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
 
     <properties>
         <!--Dependency versions-->
-        <cassandra.driver.version>3.0.2</cassandra.driver.version>
+        <cassandra.driver.version>3.1.1</cassandra.driver.version>
         <cassandra.version>3.7</cassandra.version>
         <vertx.version>3.3.0</vertx.version>
         <vertx.hk2.version>2.4.0</vertx.hk2.version>

--- a/vertx-cassandra/src/main/java/com/englishtown/vertx/cassandra/impl/JsonCassandraConfigurator.java
+++ b/vertx-cassandra/src/main/java/com/englishtown/vertx/cassandra/impl/JsonCassandraConfigurator.java
@@ -280,8 +280,13 @@ public class JsonCassandraConfigurator implements CassandraConfigurator {
 
         Integer core_connections_per_host_local = poolingConfig.getInteger("core_connections_per_host_local");
         Integer core_connections_per_host_remote = poolingConfig.getInteger("core_connections_per_host_remote");
+        Integer heartbeat_interval_seconds = poolingConfig.getInteger("heartbeat_interval_seconds");
+        Integer idle_timeout_seconds = poolingConfig.getInteger("idle_timeout_seconds");
         Integer max_connections_per_host_local = poolingConfig.getInteger("max_connections_per_host_local");
         Integer max_connections_per_host_remote = poolingConfig.getInteger("max_connections_per_host_remote");
+        Integer max_queue_size = poolingConfig.getInteger("max_queue_size");
+        Integer max_requests_per_connection_local = poolingConfig.getInteger("max_requests_per_connection_local");
+        Integer max_requests_per_connection_remote = poolingConfig.getInteger("max_requests_per_connection_remote");
         Integer new_connection_threshold_local = poolingConfig.getInteger("new_connection_threshold_local");
         Integer new_connection_threshold_remote = poolingConfig.getInteger("new_connection_threshold_remote");
 
@@ -291,27 +296,32 @@ public class JsonCassandraConfigurator implements CassandraConfigurator {
         if (core_connections_per_host_remote != null) {
             poolingOptions.setCoreConnectionsPerHost(HostDistance.REMOTE, core_connections_per_host_remote);
         }
+        if (heartbeat_interval_seconds != null) {
+            poolingOptions.setHeartbeatIntervalSeconds(heartbeat_interval_seconds);
+        }
+        if (idle_timeout_seconds != null) {
+            poolingOptions.setIdleTimeoutSeconds(idle_timeout_seconds);
+        }
         if (max_connections_per_host_local != null) {
             poolingOptions.setMaxConnectionsPerHost(HostDistance.LOCAL, max_connections_per_host_local);
         }
         if (max_connections_per_host_remote != null) {
             poolingOptions.setMaxConnectionsPerHost(HostDistance.REMOTE, max_connections_per_host_remote);
         }
+        if (max_queue_size != null) {
+            poolingOptions.setMaxQueueSize(max_queue_size);
+        }
+        if (max_requests_per_connection_local != null) {
+            poolingOptions.setMaxRequestsPerConnection(HostDistance.LOCAL, max_requests_per_connection_local);
+        }
+        if (max_requests_per_connection_remote != null) {
+            poolingOptions.setMaxRequestsPerConnection(HostDistance.REMOTE, max_requests_per_connection_remote);
+        }
         if (new_connection_threshold_local != null) {
             poolingOptions.setNewConnectionThreshold(HostDistance.LOCAL, new_connection_threshold_local);
-        } else {
-            Integer max_simultaneous_requests_local = poolingConfig.getInteger("max_simultaneous_requests_local");
-            if (max_simultaneous_requests_local != null) {
-                poolingOptions.setNewConnectionThreshold(HostDistance.LOCAL, max_simultaneous_requests_local);
-            }
         }
         if (new_connection_threshold_remote != null) {
             poolingOptions.setNewConnectionThreshold(HostDistance.REMOTE, new_connection_threshold_remote);
-        } else {
-            Integer max_simultaneous_requests_remote = poolingConfig.getInteger("max_simultaneous_requests_remote");
-            if (max_simultaneous_requests_remote != null) {
-                poolingOptions.setNewConnectionThreshold(HostDistance.REMOTE, max_simultaneous_requests_remote);
-            }
         }
 
     }

--- a/vertx-cassandra/src/test/java/com/englishtown/vertx/cassandra/impl/JsonCassandraConfiguratorTest.java
+++ b/vertx-cassandra/src/test/java/com/englishtown/vertx/cassandra/impl/JsonCassandraConfiguratorTest.java
@@ -237,10 +237,16 @@ public class JsonCassandraConfiguratorTest {
         config.put(JsonCassandraConfigurator.CONFIG_POOLING, new JsonObject()
                 .put("core_connections_per_host_local", 1)
                 .put("core_connections_per_host_remote", 2)
-                .put("max_connections_per_host_local", 3)
-                .put("max_connections_per_host_remote", 4)
-                .put("max_simultaneous_requests_local", 5)
-                .put("max_simultaneous_requests_remote", 6)
+                .put("heartbeat_interval_seconds", 3)
+                .put("idle_timeout_seconds", 4)
+                .put("max_queue_size", 5)
+                .put("max_connections_per_host_local", 6)
+                .put("max_connections_per_host_remote", 7)
+                .put("max_requests_per_connection_local", 8)
+                .put("max_requests_per_connection_remote", 9)
+                .put("new_connection_threshold_local", 10)
+                .put("new_connection_threshold_remote", 11)
+
         );
 
         configurator = new JsonCassandraConfigurator(vertx);
@@ -249,10 +255,15 @@ public class JsonCassandraConfiguratorTest {
         PoolingOptions options = configurator.getPoolingOptions();
         assertEquals(1, options.getCoreConnectionsPerHost(HostDistance.LOCAL));
         assertEquals(2, options.getCoreConnectionsPerHost(HostDistance.REMOTE));
-        assertEquals(3, options.getMaxConnectionsPerHost(HostDistance.LOCAL));
-        assertEquals(4, options.getMaxConnectionsPerHost(HostDistance.REMOTE));
-        assertEquals(5, options.getNewConnectionThreshold(HostDistance.LOCAL));
-        assertEquals(6, options.getNewConnectionThreshold(HostDistance.REMOTE));
+        assertEquals(3, options.getHeartbeatIntervalSeconds());
+        assertEquals(4, options.getIdleTimeoutSeconds());
+        assertEquals(5, options.getMaxQueueSize());
+        assertEquals(6, options.getMaxConnectionsPerHost(HostDistance.LOCAL));
+        assertEquals(7, options.getMaxConnectionsPerHost(HostDistance.REMOTE));
+        assertEquals(8, options.getMaxRequestsPerConnection(HostDistance.LOCAL));
+        assertEquals(9, options.getMaxRequestsPerConnection(HostDistance.REMOTE));
+        assertEquals(10, options.getNewConnectionThreshold(HostDistance.LOCAL));
+        assertEquals(11, options.getNewConnectionThreshold(HostDistance.REMOTE));
 
     }
 


### PR DESCRIPTION
We struggled with new driver options like max_queue_size and max_requests_per_connection not being available.